### PR TITLE
Feat/auto grow textarea

### DIFF
--- a/encryption-website/pages/index.tsx
+++ b/encryption-website/pages/index.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import TextareaAutosize from "react-textarea-autosize"
 import Image from "next/image";
 
 interface Star {
@@ -72,7 +73,7 @@ export default function Home() {
         alt="Cacti"
         width={500}
         height={200}
-        className="absolute bottom-0 left-370 -translate-x-1/2 pointer-events-none"
+        className="absolute bottom-0 right-0 pointer-events-none"
       />
       <Image
         src="/static/images/sun.svg"

--- a/encryption-website/pages/index.tsx
+++ b/encryption-website/pages/index.tsx
@@ -94,15 +94,19 @@ export default function Home() {
         "
       >
         <p className="text-2xl font-semibold text-black">Enter your text:</p>
-        <input
-          type="text"
+        {/* Used drop in library from react for handling the text input growth. 
+         * <input> can't grow tall and stays as one row, 
+         * so we either have to use <textarea> auto resize with a hook, or use TextareaAutosize
+         */}
+        <TextareaAutosize
+          minRows={1}
+          maxRows={6}
           placeholder="Type here…"
           className="
             w-150
-            h-50
             px-4
-            pt-4 pb-1
-            leading-none
+            py-2
+            resize-none
             rounded-lg
             bg-white bg-opacity-80 text-gray-900
             placeholder-gray-600


### PR DESCRIPTION
Used drop in library from react for handling the text input growth. 
<input> can't grow tall and stays as one row, so we either have to use <textarea> auto resize with a hook, or use TextareaAutosize. That's why the placeholder was in the center because it viewed the entire box as one row. 

Also made house.svg align completely with the right side. 